### PR TITLE
fix: nohoist jest/jasmine types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,19 @@
   "devDependencies": {
     "lerna": "^3.16.4"
   },
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "**/@types/jasmine",
+      "**/@types/jasmine/**",
+      "**/@types/jasminewd2",
+      "**/@types/jasminewd2/**",
+      "**/@types/jest",
+      "**/@types/jest/**"
+    ]
+  },
   "version": "1.0.0",
   "repository": "git@github.com:epsxy/starter-webapp.git",
   "author": "epsxy <epsxy@users.noreply.github.com>",


### PR DESCRIPTION
Closes #7.

@types/jest, @types/jasmine and @types/jasminewd2 got overlapping definitions which cause issues when using monorepo.

Nohoist those dependencies solves everything.